### PR TITLE
Correct grommet version to 2.0.1 instead of removed NEXT

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "grommet": "https://github.com/grommet/grommet/tarball/NEXT-stable",
+    "grommet": "^2.0.1",
     "grommet-icons": "^3.2.0",
     "react": "^16.6.1",
     "react-dom": "^16.6.1",


### PR DESCRIPTION
Self explainable. Has to be corrected as it is bad first impression of newcomers with wrong key dependency version.