### PR TITLE
Minor updates to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You should see a beautiful, mostly black and white (accessible), landing page :s
 To add grommet you first need to install our packages
 
 ```bash
-npm install grommet styled-components --save
+npm install grommet grommet-icons styled-components --save
 ```
 
 You can now add the import of the `Grommet` component.
@@ -330,7 +330,7 @@ class App extends Component {
 -           <Button icon={<Notification />} onClick={() => {}} />
 +           <Button
 +             icon={<Notification />}
-+             onClick={() => this.setState({ showSidebar: !this.state.showSidebar })}
++             onClick={() => this.setState({ showSidebar: !showSidebar })}
 +           />
           </AppBar>
           <Box direction='row' flex overflow={{ horizontal: 'hidden' }}>
@@ -365,7 +365,7 @@ class App extends Component {
 }
 ```
 
-We are just leverating React state by creating a `showSidebar` flag initially set to false.
+We are just leveraging React state by creating a `showSidebar` flag initially set to false.
 Once we click in the notification button, we toggle the `showSidebar` state. The button then serves to open and 
 close the sidebar.
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ class App extends Component {
 -           <Button icon={<Notification />} onClick={() => {}} />
 +           <Button
 +             icon={<Notification />}
-+             onClick={() => this.setState({ showSidebar: !showSidebar })}
++             onClick={() => this.setState({ showSidebar: !this.state.showSidebar })}
 +           />
           </AppBar>
           <Box direction='row' flex overflow={{ horizontal: 'hidden' }}>

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ class App extends Component {
 -           <Button icon={<Notification />} onClick={() => {}} />
 +           <Button
 +             icon={<Notification />}
-+             onClick={() => this.setState({ showSidebar: !this.state.showSidebar })}
++             onClick={() => this.setState(prevState => ({ showSidebar: !prevState.showSidebar }))}
 +           />
           </AppBar>
           <Box direction='row' flex overflow={{ horizontal: 'hidden' }}>
@@ -433,7 +433,7 @@ You may want to consider using [prettier](https://prettier.io/) to auto format f
           <Heading level='3' margin='none'>My App</Heading>
           <Button
             icon={<Notification />}
-            onClick={() => this.setState({ showSidebar: !this.state.showSidebar })}
+            onClick={() => this.setState(prevState => ({ showSidebar: !prevState.showSidebar }))}
           />
         </AppBar>
         <Box direction='row' flex overflow={{ horizontal: 'hidden' }}>


### PR DESCRIPTION
- Include `grommet-icons` in `npm install` since it is used later in the tutorial
- Fix typo of "leverating" to "leveraging" 
- Per [React documentation](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous), using `this.state` inside of `this.setState` is not recommended. In these cases, pass in `prevState` and use that instead.