### PR TITLE
Fixing difference in font type size in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const theme = {
   global: {
     font: {
       family: 'Roboto',
-      size: '14px',
+      size: '18px',
       height: '20px',
     },
   },


### PR DESCRIPTION
There was a difference in the font sizes in the README.md. It threw me off when I was following the tutorial yesterday.